### PR TITLE
Fix field name edit issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can do the following as of now:
 Want to contribute? Feel free to submit pull requests, create issues, and help with existing issues. The goal here is to create an up to date tool for easy RethinkDB administration.
 
 # Known Bugs
-- [ ] When editing a field, if the field name is changed, it will add it, but not delete the old one.
+- [X] When editing a field, if the field name is changed, it will add it, but not delete the old one.
 
 # Roadmap Features
 - [ ] Import JSON / CSV into Tables

--- a/client/src/screens/table/index.js
+++ b/client/src/screens/table/index.js
@@ -21,7 +21,7 @@ import { Loader } from '../../shared/components';
 import './table.scss';
 
 // Default data objects
-const defaultEditData = { field: '', value: '' };
+const defaultEditData = { originalField: '', field: '', value: '' };
 
 const defaultCreateData = {
   type: 'field', // or collection
@@ -161,6 +161,7 @@ const DatabaseTable = props => {
    */
   const openEditFieldModal = key => {
     setEditFieldData({
+      originalField: key,
       field: key,
       value: (key.includes('.') ? _.get(doc, key) : doc[key])
     });
@@ -386,6 +387,11 @@ const DatabaseTable = props => {
     let field = editFieldData.field;
     let d = doc;
 
+    // Compare fields, see if the field changed.
+    if (editFieldData.originalField !== editFieldData.field) {
+      d = _.omit(d, editFieldData.originalField);
+    }
+
     if (field.includes('.')) d = _.set(d, field, editFieldData.value);
     else d[field] = editFieldData.value;
 
@@ -394,7 +400,7 @@ const DatabaseTable = props => {
         .db(database)
         .table(table)
         .filter({ id: doc.id })
-        .update(d)
+        .replace(d)
         .run(props.rethink.connection);
 
       if (res.replaced === 0) return message.error('Unable to update field.');

--- a/reql-ws/README.md
+++ b/reql-ws/README.md
@@ -1,0 +1,4 @@
+# ReQL Websocket Server
+
+## TODO:
+- Add user authentication layer.


### PR DESCRIPTION
# Problem 

When editing a field name in a document, the original field name would stay, and a new field & value pair was created as well. 

# Solution 

Now when editing a field name, the old field is removed from the document before it is updated in the database. Also, we had to change `update` to `replace` in order for this to work.